### PR TITLE
Small improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ After that, restart the docker and you'll be great by the Unifi-Video wizard tha
 docker run \
         -p 7443:7443 -p 7445:7445 -p 7446:7446 -p 7447:7447 -p 7080:7080 -p 6666:6666 \
 	-v unifi_data:/var/lib/unifi-video -v unifi_videos:/usr/lib/unifi-video/data/videos -v unifi_logs:/var/log/unifi-video  \
-        --name unifi \
+        --name unifi-video \
         pducharme/unifi-video-controller \
 ```

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ docker run \
         -p 7443:7443 -p 7445:7445 -p 7446:7446 -p 7447:7447 -p 7080:7080 -p 6666:6666 \
 	-v unifi_data:/var/lib/unifi-video -v unifi_videos:/usr/lib/unifi-video/data/videos -v unifi_logs:/var/log/unifi-video  \
         --name unifi \
-        pducharme/UniFi-Video-Controller \
+        pducharme/unifi-video-controller \
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a docker for use on Unraid 6.x for the UniFi-Video controller.
 
-On first run, the file `system.properties` will be created in your data directory, *you* must add `is_default=true` as the first line in order to force the wizard to run. If the file isn't created automatically, create it yourself.
+Set your local data, videos and logs directories in the `docker run` command.
+
+The first run should create the file `system.properties` in your data directory. If it doesn't, create it yourself. *You* must add `is_default=true` as the first line in order to force the wizard to run.
 
 Restart the docker, visit http://localhost:7080 and you'll start the Unifi Video wizard.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is a docker for use on Unraid 6.x for the UniFi-Video controller.
 
-Please note that on first run, it will create a system.properties that you will need to edit to add on the first line: is_default=true
+On first run, the file `system.properties` will be created in your data directory, *you* must add `is_default=true` as the first line in order to force the wizard to run. If the file isn't created automatically, create it yourself.
 
-After that, restart the docker and you'll be great by the Unifi-Video wizard that will let you set a User/Pass for your Unifi-Video controller.
+Restart the docker, visit http://localhost:7080 and you'll start the Unifi Video wizard.
 
 ## Run it
 ```

--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ After that, restart the docker and you'll be great by the Unifi-Video wizard tha
 ## Run it
 ```
 docker run \
-        -p 7443:7443 -p 7445:7445 -p 7446:7446 -p 7447:7447 -p 7080:7080 -p 6666:6666 \
-	-v unifi_data:/var/lib/unifi-video -v unifi_videos:/usr/lib/unifi-video/data/videos -v unifi_logs:/var/log/unifi-video  \
         --name unifi-video \
-        pducharme/unifi-video-controller \
+        -p 7443:7443 \
+        -p 7445:7445 \
+        -p 7446:7446 \
+        -p 7447:7447 \
+        -p 7080:7080 \
+        -p 6666:6666 \
+	-v <data dir>:/var/lib/unifi-video \
+        -v <videos dir>:/usr/lib/unifi-video/data/videos \
+        -v <logs dir>:/var/log/unifi-video  \
+        pducharme/unifi-video-controller
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Set your local data, videos and logs directories in the `docker run` command.
 
 The first run should create the file `system.properties` in your data directory. If it doesn't, create it yourself. *You* must add `is_default=true` as the first line in order to force the wizard to run.
 
-Restart the docker, visit http://localhost:7080 and you'll start the Unifi Video wizard.
+Restart the docker, visit http://localhost:7080 or http://<ip.address>:7080/ to start the Unifi Video wizard.
 
 ## Run it
 ```


### PR DESCRIPTION
Hi, I recently used your unifi-video docker image and thought I'd improve your README.md a little. I tried to break it apart into logical commits so that if you don't like any specific one you can just skip it.

The first one is required though, your docker image name on docker hub is lower case. The second one is a good idea because 'unifi' is actually the controller for APs and switches. The one option per line is just a personal preference, but I think it makes it clearer when setting up and it helps the options stand out. Changing the name of the local directory to something that should fail if used will help fix using the wrong local dir.

And the text improvements to the README, hopefully you like them. :)