### PR TITLE
Add timezone to run command example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ docker run \
         -v <data dir>:/var/lib/unifi-video \
         -v <videos dir>:/usr/lib/unifi-video/data/videos \
         -v <logs dir>:/var/log/unifi-video \
+        -e TZ=America/Los_Angeles \
         -e PUID=99 \
         -e PGID=100 \
         pducharme/unifi-video-controller


### PR DESCRIPTION
This came from the paste of your run command for unraid, which has the timezone set. Seems like we should do it for us non-unraid docker users. :)