### PR TITLE
Add a DEBUG variable to use --debug in start command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ docker run \
         -v <logs dir>:/var/log/unifi-video \
         -e PUID=99 \
         -e PGID=100 \
+        -e DEBUG=1 \
         pducharme/unifi-video-controller
 ```

--- a/init.sh
+++ b/init.sh
@@ -2,7 +2,8 @@
 set -e
 
 # Change user nobody's UID to custom or match unRAID.
-export PUID=$(echo "${PUID}" | sed -e 's/^[ \t]*//')
+export PUID
+PUID=$(echo "${PUID}" | sed -e 's/^[ \t]*//')
 if [[ ! -z "${PUID}" ]]; then
   echo "[info] PUID defined as '${PUID}'" | ts '%Y-%m-%d %H:%M:%.S'
 else
@@ -14,7 +15,8 @@ fi
 usermod -o -u "${PUID}" unifi-video &>/dev/null
 
 # Change group users to GID to custom or match unRAID.
-export PGID=$(echo "${PGID}" | sed -e 's/^[ \t]*//')
+export PGID
+PGID=$(echo "${PGID}" | sed -e 's/^[ \t]*//')
 if [[ ! -z "${PGID}" ]]; then
   echo "[info] PGID defined as '${PGID}'" | ts '%Y-%m-%d %H:%M:%.S'
 else
@@ -39,8 +41,8 @@ if [[ ! -f "/var/lib/unifi-video/perms.txt" ]]; then
   exit_code_chmod=$?
   set -e
 
-  if (( ${exit_code_chown} != 0 || ${exit_code_chmod} != 0 )); then
-    echo "[warn] Unable to chown/chmod ${volumes}, assuming SMB mountpoint"
+  if (( exit_code_chown != 0 || exit_code_chmod != 0 )); then
+    echo "[warn] Unable to chown/chmod ${volumes[*]}, assuming SMB mountpoint"
   fi
 
   echo "This file prevents permissions from being applied/re-applied to /config, if you want to reset permissions then please delete this file and restart the container." > /var/lib/unifi-video/perms.txt

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+unifi_video_opts=""
 
 function graceful_shutdown {
   echo -n "Stopping unifi-video... " 
-  /usr/sbin/unifi-video --nodetach stop
-  if [[ $? -eq 0 ]]; then
+  if /usr/sbin/unifi-video --nodetach stop; then
     echo "done."
     exit 0
   else
@@ -15,9 +15,19 @@ function graceful_shutdown {
 # Trap SIGTERM for graceful exit
 trap graceful_shutdown SIGTERM
 
+if [[ -z ${DEBUG} ]]; then
+  DEBUG=0
+fi
+
 # Run the unifi-video daemon the unifi-video way
 echo -n "Starting unifi-video... "
-/usr/sbin/unifi-video start
+
+if [[ ${DEBUG} -eq 1 ]]; then
+  echo "[debug] Running unifi-video service with --debug."
+  unifi_video_opts="--debug"
+fi
+
+/usr/sbin/unifi-video "${unifi_video_opts}" start
 echo "done."
 
 while true; do


### PR DESCRIPTION
This just lets you do `-e DEBUG=1` if you want the full spew from the unifi-video daemon. Defaults to off/0 if not specified, tested with all three options (1, 0 and not specified).