### PR TITLE
Remove .deb and .patch files after being installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update && \
   wget -q http://dl.ubnt.com/firmwares/unifi-video/3.7.1/unifi-video_3.7.1~Ubuntu16.04_amd64.deb && \
   dpkg -i unifi-video_3.7.1~Ubuntu16.04_amd64.deb && \
   patch -N /usr/sbin/unifi-video /unifi-video.patch && \
+  rm /unifi-video_3.7.1~Ubuntu16.04_amd64.deb && \
+  rm /unifi-video.patch && \
   chmod 755 /run.sh
 
 # Volumes


### PR DESCRIPTION
issue #31 ; This will remove the unifi-video_*.deb and unifi-video.patch files from the image after they have been installed to help save space.