### PR TITLE
Upgrade to Unifi Video 3.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
   apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
   apt-get install -y wget sudo moreutils patch && \
   apt-get install -y mongodb-server openjdk-8-jre-headless jsvc && \
-  wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.8.2/unifi-video.Ubuntu16.04_amd64.v3.8.2.deb && \
+  wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.8.3/unifi-video.Ubuntu16.04_amd64.v3.8.3.deb && \
   dpkg -i unifi-video.deb && \
   patch -N /usr/sbin/unifi-video /unifi-video.patch && \
   rm /unifi-video.deb && \


### PR DESCRIPTION
Version 3.8.3 of the controller (with matching camera firmware) has been published, this gets the docker image up to date. 