### PR TITLE
Enable IPv6 for camera feeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD run.sh /run.sh
 RUN apt-get update && \
   apt-get install -y apt-utils && \
   apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
-  apt-get install -y wget sudo moreutils patch && \
+  apt-get install -y wget sudo moreutils patch socat && \
   apt-get install -y mongodb-server openjdk-8-jre-headless jsvc && \
   wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.8.5/unifi-video.Ubuntu16.04_amd64.v3.8.5.deb && \
   dpkg -i unifi-video.deb && \

--- a/run.sh
+++ b/run.sh
@@ -90,6 +90,10 @@ else
   exit 1
 fi
 
+# Run socat to proxy IPv6 address for 7445 and 7446
+setsid socat tcp6-listen:7445,fork,ipv6only=1 tcp4:127.0.0.1:7445
+setsid socat tcp6-listen:7446,fork,ipv6only=1 tcp4:127.0.0.1:7446
+
 while true; do
   sleep 1
 done

--- a/run.sh
+++ b/run.sh
@@ -91,8 +91,8 @@ else
 fi
 
 # Run socat to proxy IPv6 address for 7445 and 7446
-setsid socat tcp6-listen:7445,fork,ipv6only=1 tcp4:127.0.0.1:7445
-setsid socat tcp6-listen:7446,fork,ipv6only=1 tcp4:127.0.0.1:7446
+(socat tcp6-listen:7445,fork,ipv6only=1 tcp4:127.0.0.1:7445 &)
+(socat tcp6-listen:7446,fork,ipv6only=1 tcp4:127.0.0.1:7446 &)
 
 while true; do
   sleep 1


### PR DESCRIPTION
IPv6 of camera feed is broken on the original Unifi NVR software (fortunately any other things worked well).
So I decided to workaround the issue by port proxies using socat.
Now, all functionalities should be able to work on both IPv4 and IPv6 ports.

See also:
https://community.ubnt.com/t5/UniFi-Video/IPv6-NVR-issues/m-p/1961790#M81036