### PR TITLE
Remove log volume from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ docker run \
         -p 6666:6666 \
         -v <data dir>:/var/lib/unifi-video \
         -v <videos dir>:/usr/lib/unifi-video/data/videos \
-        -v <logs dir>:/var/log/unifi-video \
         -e TZ=America/Los_Angeles \
         -e PUID=99 \
         -e PGID=100 \


### PR DESCRIPTION
Now that logs have moved into the data dir, there isn't really any reason for it to have a volume. So let's nuke it. This should only go in after we're back on 3.9.2.