### PR TITLE
Create the logs directory, make permissions fixing better w/ 664 for …

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ mkdir -p /var/lib/unifi-video/logs
 if [[ ! -f "/var/lib/unifi-video/perms.txt" ]]; then
   echo "[info] Setting permissions recursively on volume mappings..." | ts '%Y-%m-%d %H:%M:%.S'
 
-  volumes=( "/var/lib/unifi-video" "/var/lib/unifi-video/data/videos" )
+  volumes=( "/var/lib/unifi-video" )
 
   set +e
 

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ mkdir -p /var/lib/unifi-video/logs
 if [[ ! -f "/var/lib/unifi-video/perms.txt" ]]; then
   echo "[info] Setting permissions recursively on volume mappings..." | ts '%Y-%m-%d %H:%M:%.S'
 
-  volumes=( "/var/lib/unifi-video" "/var/lib/unifi-video/videos" )
+  volumes=( "/var/lib/unifi-video" "/var/lib/unifi-video/data/videos" )
 
   set +e
 


### PR DESCRIPTION
Now that logs isn't its own volume, the directory needs to exist at startup or there are errors.

Also, the permissions fixer was just making everything +x. Using find on dirs and files is cleaner, allowing 664 for files and 775 for folders.

I'm building this now and will test shortly.

Still needs to wait until 3.9.2 actually works though. :/