### PR TITLE
Switch to ENTRYPOINT.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ VOLUME /var/lib/unifi-video /var/log/unifi-video
 EXPOSE 7442 7443 7445 7446 7447 7080 6666
 
 # Run this potato
-CMD ["/run.sh"]
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
I think ENTRYPOINT is more correct, CMD is for when users might over ride. This should only get merged w/ 3.9.2 when that is working. Building a test image now.