### PR TITLE
Add --verbose option for more spew.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,7 @@ fi
 # Run with --debug if DEBUG=1
 if [[ ${DEBUG} -eq 1 ]]; then
   echo "[debug] Running unifi-video service with --debug."
-  unifi_video_opts="--debug"
+  unifi_video_opts="--verbose --debug"
 fi
 
 # Run the unifi-video daemon the unifi-video way


### PR DESCRIPTION
Why do they have a `--verbose` *and* `--debug` option? Why doesn't debug enable verbose? Or does it? Building a test image now. :/