### PR TITLE
Add Makefile and improve ease of release and tagging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM phusion/baseimage:latest
 MAINTAINER pducharme@me.com
 
+ARG UNIFI_VIDEO_VERSION
+
 # Set correct environment variables
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive
@@ -18,7 +20,7 @@ RUN apt-get update && \
   apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
   apt-get install -y wget sudo moreutils patch && \
   apt-get install -y mongodb-server openjdk-8-jre-headless jsvc && \
-  wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.9.2/unifi-video.Ubuntu16.04_amd64.v3.9.2.deb && \
+  wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${UNIFI_VIDEO_VERSION}/unifi-video.Ubuntu16.04_amd64.v${UNIFI_VIDEO_VERSION}.deb && \
   dpkg -i unifi-video.deb && \
   patch -N /usr/sbin/unifi-video /unifi-video.patch && \
   rm /unifi-video.deb && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+NAME=pducharme/unifi-video-controller
+VERSION=3.9.2
+
+.PHONY: all build tag_latest release
+
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+all: build
+
+build:	## Builds unifi-video docker image.
+	docker build --no-cache --build-arg UNIFI_VIDEO_VERSION=$(VERSION) -t $(NAME):$(VERSION) --rm=true .
+
+tag_latest:	## Tags this version of unifi-video in docker.
+	docker tag $(NAME):$(VERSION) $(NAME):latest
+
+release: tag_latest	## Checks for built image, pushes to docker and echos git tag commands.
+	@if ! docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	docker push $(NAME)
+	@echo "*** Don't forget to create a tag. git tag rel-$(VERSION) && git push origin rel-$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ tag_latest:	## Tags this version of unifi-video in docker.
 release: tag_latest	## Checks for built image, pushes to docker and echos git tag commands.
 	@if ! docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	docker push $(NAME)
-	@echo "*** Don't forget to create a tag. git tag rel-$(VERSION) && git push origin rel-$(VERSION)"
+	@echo "*** Don't forget to create a tag. git tag -a $(VERSION) -m \"Version ${VERSION}\" && git push origin $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=pducharme/unifi-video-controller
 VERSION=3.9.2
 
-.PHONY: all build tag_latest release
+.PHONY: help all build tag_latest release
 
 help:
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'


### PR DESCRIPTION
This makes the version in the Dockerfile an argument passed at build time, as seen in the Makefile. It should also simplify releases for @pducharme. But that part is basically impossible for me to test. A test of building is in flight now.

This shouldn't be merged until 3.9.2 works and the whole thing is tested.

Based on https://github.com/ctindel/ubiquiti-docker/blob/master/unifi-video/Makefile