### PR TITLE
Use version 3.4 of mongodb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,15 @@ RUN apt-get update && \
   apt-get install -y apt-utils && \
   apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
   apt-get install -y wget sudo moreutils patch && \
-  apt-get install -y mongodb-server openjdk-8-jre-headless jsvc && \
-  wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.9.2/unifi-video.Ubuntu16.04_amd64.v3.9.2.deb && \
+  apt-get install -y openjdk-8-jre-headless jsvc
+
+# Add mongodb 3.4 repo and install
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
+  echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" > /etc/apt/sources.list.d/mongodb-org-3.4.list && \
+  apt-get update && apt-get install -y mongodb-org-server
+
+# Get, install and patch unifi-video
+RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v3.9.2/unifi-video.Ubuntu16.04_amd64.v3.9.2.deb && \
   dpkg -i unifi-video.deb && \
   patch -N /usr/sbin/unifi-video /unifi-video.patch && \
   rm /unifi-video.deb && \


### PR DESCRIPTION
From @ctindel's unifi-video docker image, may as well run an up to date-ish version of mongodb. It looks like 3.4 works, both in testing and since it works in his docker image.

Should wait and go in when we figure out what is wrong with 3.9.2. :/