### PR TITLE
Point videos volume to real path, add and arrange ports in docker-compose.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 VOLUME ["/var/lib/unifi-video"]
 
 # Video storage, for seperation of data
-VOLUME ["/usr/lib/unifi-video/data/videos"]
+VOLUME ["/var/lib/unifi-video/videos"]
 
 # RTMP via the controller
 EXPOSE 1935/tcp

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,16 +4,19 @@ services:
     build: .
     container_name: unifi-video-controller
     ports:
+      - 1935:1935
+      - 6666:6666
+      - 7004:7004
+      - 7080:7080
       - 7442:7442
       - 7443:7443
+      - 7444:7444
       - 7445:7445
       - 7446:7446
       - 7447:7447
-      - 7080:7080
-      - 6666:6666
     volumes:
       - ./run/data:/var/lib/unifi-video
-      - ./run/logs:/var/log/unifi-video
+      - ./run/videos:/var/lib/unifi-video/videos
     environment:
       - TZ=America/Los_Angeles
       - DEBUG=1


### PR DESCRIPTION
Make it all consistent with real life. At some point in the past, they moved videos to /var/lib/unifi-video and used a symlink in /usr/lib/unifi-video. Might as well mount in the right place.