### PR TITLE
Update to v3.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM phusion/baseimage:latest
 MAINTAINER pducharme@me.com
 
 # Version
-ENV version 3.9.2
+ENV version 3.9.3
 
 # Set correct environment variables
 ENV HOME /root


### PR DESCRIPTION
Will be available for testing shortly via `docker pull fryfrog/unifi-video-controller:testing`, throwing up the ol' pull request in the mean time.