### PR TITLE
Track a specific version of baseimage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.10.0
 MAINTAINER pducharme@me.com
 
 # Version


### PR DESCRIPTION
Good suggestion from @ctindel to *not* track latest, for when updates might break it all.