### PR TITLE
Update to latest phusion/baseimage and unifi-video beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.10.0
+FROM phusion/baseimage:0.11
 MAINTAINER pducharme@me.com
 # Version
 ENV version 3.9.8-beta.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM phusion/baseimage:0.10.0
 MAINTAINER pducharme@me.com
-
 # Version
-ENV version 3.9.7
+ENV version 3.9.8-beta.3
 
 # Set correct environment variables
 ENV HOME /root


### PR DESCRIPTION
Looks like baseimage has made it to `0.11` and unifi-video to `3.9.8-beta3`. Do it in the beta branch for testing.