### PR TITLE
Documented hostname parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Restart the docker, visit http://localhost:7080 or http://<ip.address>:7080/ to 
 ```
 docker run \
         --name unifi-video \
+        --hostname nvr.example.com \
         --cap-add SYS_ADMIN \
         --cap-add DAC_READ_SEARCH \
         -p 10001:10001 \


### PR DESCRIPTION
Mentioning the hostname is key for making the controller work under a reverse proxy, without it you will not be able to use it as it will redirect the browser to the IP address.

Fixes: #148