### PR TITLE
Remove the hard dependency on CAP_SYS_ADMIN (partial fix for #167)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75
 # Get, install and patch unifi-video
 RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${version}/unifi-video.Ubuntu18.04_amd64.v${version}.deb && \
   dpkg -i unifi-video.deb && \
-  patch -N /usr/sbin/unifi-video /unifi-video.patch && \
+  patch -lN /usr/sbin/unifi-video /unifi-video.patch && \
   rm /unifi-video.deb && \
   rm /unifi-video.patch && \
   chmod 755 /run.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Restart the docker, visit http://localhost:7080 or http://<ip.address>:7080/ to 
 ```
 docker run \
         --name unifi-video \
-        --cap-add SYS_ADMIN \
         --cap-add DAC_READ_SEARCH \
         -p 10001:10001 \
         -p 1935:1935 \
@@ -27,9 +26,11 @@ docker run \
         -p 7447:7447 \
         -v <data dir>:/var/lib/unifi-video \
         -v <videos dir>:/var/lib/unifi-video/videos \
+        --tmpfs /var/cache/unifi-video \
         -e TZ=America/Los_Angeles \
         -e PUID=99 \
         -e PGID=100 \
+        -e CREATE_TMPFS=no \
         -e DEBUG=1 \
         pducharme/unifi-video-controller
 ```
@@ -39,11 +40,3 @@ To avoid MongoDB errors that cause UniFi Video to hang at the "upgrading" screen
 
 You can then specify a different directory for your actual video files, which do not need to be located in a docker volume. E.g. `-v D:\Recordings:/var/lib/unifi-video/videos`
 
-#  tmpfs mount error
-
-```
-mount: tmpfs is write-protected, mounting read-only
-mount: cannot mount tmpfs read-only
-```
-
-If you get this tmpfs mount error, add `--security-opt apparmor:unconfined \` to your list of run options. This error has been seen on Ubuntu, but may occur on other platforms as well.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,13 +17,11 @@ services:
     volumes:
       - ./run/data:/var/lib/unifi-video
       - ./run/videos:/var/lib/unifi-video/videos
+    tmpfs:
+      - /var/cache/unifi-video
     environment:
       - TZ=America/Los_Angeles
       - DEBUG=1
+      - CREATE_TMPFS=no
     cap_add:
-      - SYS_ADMIN
       - DAC_READ_SEARCH
-# Uncomment security option below to set apparmor unconfined if "tmpfs is write-protected, mounting read-only" error is seen.
-# Known to happen on ubuntu, synology, and other platforms.
-#    security_opt:
-#      - apparmor:unconfined

--- a/unifi-video.patch
+++ b/unifi-video.patch
@@ -1,6 +1,14 @@
---- unifi-video.orig	2019-04-20 17:00:21.142172604 -0700
-+++ unifi-video	2019-04-20 17:01:04.763373991 -0700
-@@ -275,7 +275,7 @@
+--- unifi-video.orig   2020-03-23 03:29:04.794581615 +0000
++++ unifi-video        2020-03-23 03:39:22.856719123 +0000
+@@ -17,6 +17,7 @@
+ MAINJAR="${BASEDIR}/lib/airvision.jar"
+
+ ENABLE_TMPFS=yes
++CREATE_TMPFS=${CREATE_TMPFS:-yes}
+ TMPFS_SIZE=15%
+
+ UFV_VERBOSE=
+@@ -276,7 +277,7 @@
  		 -Dcom.sun.management.jmxremote.authenticate=false \
  		 -Dcom.sun.management.jmxremote.port=${JVM_JMXREMOTE_PORT}"
  	[ -z "${JVM_JMXREMOTE_HOST}" ] && \
@@ -9,7 +17,7 @@
  	[ -z "${JVM_JMXREMOTE_HOST}" ] || \
  		JVM_OPTS="${JVM_OPTS} -Djava.rmi.server.hostname=${JVM_JMXREMOTE_HOST}"
  
-@@ -335,7 +335,6 @@
+@@ -336,13 +337,12 @@
  	start)
  	require_root
      update_limits
@@ -17,7 +25,14 @@
          echo 0x10 > /proc/self/coredump_filter
  		if is_service_running "${PIDFILE}" >/dev/null; then
  			log_verbose "${NAME} is already running..."
-@@ -352,7 +351,6 @@
+		else
+			[ -d /var/run/${NAME} ] || mkdir -p /var/run/${NAME}
+-			[ "x${ENABLE_TMPFS}" = "xyes" ] && prepare_tmpfs ${TMPFS_DIR} ${TMPFS_SIZE}
++			[ "x${CREATE_TMPFS}" = "xyes" ] && prepare_tmpfs ${TMPFS_DIR} ${TMPFS_SIZE}
+			[ -d "${BASEDIR}/work/Catalina" ] && rm -rf "${BASEDIR}/work/Catalina"
+                         log "Hardware type:${HWTYPE}"
+                         check_and_kill_ems_if_running$
+@@ -353,7 +353,6 @@
  		;;
  	stop)
   	require_root


### PR DESCRIPTION
#### Changes made
Implements the solution (new environment variable) discussed in #167. I left the default as the old behavior to avoid breaking anything.

In the Dockerfile I switched patch into whitespace-insensitive mode because getting the whitespace byte-for-byte equivalent was taking longer than the rest of the changes combined.

#### Testing
Seems to be up and running happily on my setup :D

I explicitly tested the `docker run` command and everything seems to come up happily. Unfortunately I don't have a good way to test the docker-compose changes but I think they're right :S