### PR TITLE
Workaround for mongodb package error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75
     patch \
     sudo \
     tzdata \
-    mongodb-org-server \
-    mongodb-org-shell \
     moreutils \
-    wget
+    wget && \
+  ln -s /bin/true /usr/local/bin/systemctl && \
+  apt-get install -y mongodb-org-server mongodb-org-shell && \
+  rm /usr/local/bin/systemctl
 
 # Get, install and patch unifi-video
 RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${version}/unifi-video.Ubuntu18.04_amd64.v${version}.deb && \


### PR DESCRIPTION
Fixes pducharme/UniFi-Video-Controller#195

Uses the workaround found here: https://developer.mongodb.com/community/forums/t/mongodb-org-server-postinst-systemctl-not-found/9232/6