### PR TITLE
Fix log4j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,14 @@ RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${version}/uni
   rm /unifi-video.patch && \
   chmod 755 /run.sh
 
+# Patch log4j vuln
+RUN wget -q -O apache-log4j-2.15.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.15.0/apache-log4j-2.15.0-bin.tar.gz && \
+  tar -zxf apache-log4j-2.15.0-bin.tar.gz apache-log4j-2.15.0-bin/log4j-api-2.15.0.jar apache-log4j-2.15.0-bin/log4j-core-2.15.0.jar apache-log4j-2.15.0-bin/log4j-slf4j-impl-2.15.0.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-api-2.15.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-core-2.15.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-slf4j-impl-2.15.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
+   rm -fr /apache-log4j-2.15.0-bin.tar.gz /apache-log4j-2.15.0-bin
+
 # RTMP, RTMPS & RTSP, Inbound Camera Streams & Camera Management (NVR Side), UVC-Micro Talkback (Camera Side)
 # HTTP & HTTPS Web UI + API, Video over HTTP & HTTPS
 EXPOSE 1935/tcp 7444/tcp 7447/tcp 6666/tcp 7442/tcp 7004/udp 7080/tcp 7443/tcp 7445/tcp 7446/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN wget -q -O apache-log4j-2.15.0-bin.tar.gz https://dlcdn.apache.org/logging/l
   install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-api-2.15.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
   install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-core-2.15.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
   install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-slf4j-impl-2.15.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
-   rm -fr /apache-log4j-2.15.0-bin.tar.gz /apache-log4j-2.15.0-bin
+  rm -fr /apache-log4j-2.15.0-bin.tar.gz /apache-log4j-2.15.0-bin
 
 # RTMP, RTMPS & RTSP, Inbound Camera Streams & Camera Management (NVR Side), UVC-Micro Talkback (Camera Side)
 # HTTP & HTTPS Web UI + API, Video over HTTP & HTTPS

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,12 @@ RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${version}/uni
   chmod 755 /run.sh
 
 # Patch log4j vuln
-RUN wget -q -O apache-log4j-2.16.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.16.0/apache-log4j-2.16.0-bin.tar.gz && \
-  tar -zxf apache-log4j-2.16.0-bin.tar.gz apache-log4j-2.16.0-bin/log4j-api-2.16.0.jar apache-log4j-2.16.0-bin/log4j-core-2.16.0.jar apache-log4j-2.16.0-bin/log4j-slf4j-impl-2.16.0.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-api-2.16.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-core-2.16.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-slf4j-impl-2.16.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
-  rm -fr /apache-log4j-2.16.0-bin.tar.gz /apache-log4j-2.16.0-bin
+RUN wget -q -O apache-log4j-2.17.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.17.0/apache-log4j-2.17.0-bin.tar.gz && \
+  tar -zxf apache-log4j-2.17.0-bin.tar.gz apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar apache-log4j-2.17.0-bin/log4j-slf4j-impl-2.17.0.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.17.0-bin/log4j-api-2.17.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.17.0-bin/log4j-core-2.17.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.17.0-bin/log4j-slf4j-impl-2.17.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
+  rm -fr /apache-log4j-2.17.0-bin.tar.gz /apache-log4j-2.17.0-bin
 
 # RTMP, RTMPS & RTSP, Inbound Camera Streams & Camera Management (NVR Side), UVC-Micro Talkback (Camera Side)
 # HTTP & HTTPS Web UI + API, Video over HTTP & HTTPS

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,12 @@ RUN wget -q -O unifi-video.deb https://dl.ubnt.com/firmwares/ufv/v${version}/uni
   chmod 755 /run.sh
 
 # Patch log4j vuln
-RUN wget -q -O apache-log4j-2.15.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.15.0/apache-log4j-2.15.0-bin.tar.gz && \
-  tar -zxf apache-log4j-2.15.0-bin.tar.gz apache-log4j-2.15.0-bin/log4j-api-2.15.0.jar apache-log4j-2.15.0-bin/log4j-core-2.15.0.jar apache-log4j-2.15.0-bin/log4j-slf4j-impl-2.15.0.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-api-2.15.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-core-2.15.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
-  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.15.0-bin/log4j-slf4j-impl-2.15.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
-  rm -fr /apache-log4j-2.15.0-bin.tar.gz /apache-log4j-2.15.0-bin
+RUN wget -q -O apache-log4j-2.16.0-bin.tar.gz https://dlcdn.apache.org/logging/log4j/2.16.0/apache-log4j-2.16.0-bin.tar.gz && \
+  tar -zxf apache-log4j-2.16.0-bin.tar.gz apache-log4j-2.16.0-bin/log4j-api-2.16.0.jar apache-log4j-2.16.0-bin/log4j-core-2.16.0.jar apache-log4j-2.16.0-bin/log4j-slf4j-impl-2.16.0.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-api-2.16.0.jar /usr/lib/unifi-video/lib/log4j-api-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-core-2.16.0.jar /usr/lib/unifi-video/lib/log4j-core-2.1.jar && \
+  install --backup -m 400 -o 1003 -g 104 -T apache-log4j-2.16.0-bin/log4j-slf4j-impl-2.16.0.jar /usr/lib/unifi-video/lib/log4j-slf4j-impl-2.1.jar && \
+  rm -fr /apache-log4j-2.16.0-bin.tar.gz /apache-log4j-2.16.0-bin
 
 # RTMP, RTMPS & RTSP, Inbound Camera Streams & Camera Management (NVR Side), UVC-Micro Talkback (Camera Side)
 # HTTP & HTTPS Web UI + API, Video over HTTP & HTTPS


### PR DESCRIPTION
Ok, let's try this again.  I've pushed 2.17.0 to my repo on that fix_log4j branch.  pull :latest from paulcarlucci/unifi-video-controller if you want my build.  Deal?  Deal.

----

Alright, let's try this again.  THIS one swaps in log4j 2.17.0 and renames it as 2.1.0.  Folks are reporting that the prior attempt with setting the JMX flag was no bueno.  And 2.16 too... whatever.  This entire comment is a mess of edits.

Again if you wanna try my build it's at https://hub.docker.com/repository/docker/paulcarlucci/unifi-video-controller 

The 3.10.13-log4j_2.16.0 tag is the correct one as I deleted the 3.10.13-log4j one with the ineffective patch.  (more edit since we're up to 2.17 now... sigh simply pull :latest)

The patch method in this PR is jpoblocki's as shows here: https://community.ui.com/questions/Mitigating-the-Java-Log4J-exploit-in-UniFi-Video-on-Debian-Ubuntu/c59621d2-3cbf-48aa-9780-76477e0b1d39 

edit: went from 2.15 to 2.16 to 2.17